### PR TITLE
Add Ability to use Command Line Options in jq

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ json-query-wrapper is a wrapper for the popular command-line JSON processor "[jq
 ## Installation
 
 ```bash
-$ composer require invoicesharing/json-query-wrapper
+$ composer require estahn/json-query-wrapper
 ```
 
 ## Usage
@@ -57,6 +57,31 @@ $jq = JsonQueryWrapper\JsonQueryFactory::create();
 $jq->setDataProvider(new JsonQueryWrapper\DataProvider\File('test.json');
 $jq->run('.Foo.Bar == "33"'); # Returns bool(true)
 ```
+
+## Command Line Options
+
+This enables passing additional command line options to `jq` to customize output and behavior. Currently, the following options are supported:
+
+| Option | `jq` Option | Default? | Description |
+| --- | --- | --- | --- |
+| OPTION_EXIT_BASED_ON_OUTPUT | -e | no | set exit status based on whether output was successful |
+| OPTION_INPUT_RAW | -R | no | don't parse input as JSON |
+| OPTION_NULL_INPUT | -n | no | don't read any input at all |
+| OPTION_OUTPUT_COLORIZE | -C | no | colorize output on shell |
+| OPTION_OUTPUT_COMPACT | -c | no | compact output, don't pretty print |
+| OPTION_OUTPUT_JOIN | -j | no | join each line of output, don't print newline |
+| OPTION_OUTPUT_MONOCHROME | -M | yes | don't colorize output on the shell, print plainly |
+| OPTION_OUTPUT_RAW | -r | no | write output directly, don't convert to JSON |
+| OPTION_OUTPUT_SORT_KEYS | -S | no | sort keys in the output |
+
+If not explicitly set, only the monochrome option will be set. More information about all these command line options can be found in the [jq manual](https://stedolan.github.io/jq/manual/#Invokingjq). To use command line options, just pass an array to the `JsonQueryFactory::create` or `JsonQueryFactory::createWith` methods:
+
+```php
+$options = [JsonQueryWrapper\CommandLineOption\CommandLineOption::OPTION_OUTPUT_JOIN, JsonQueryWrapper\CommandLineOption\CommandLineOption::OPTION_OUTPUT_SORT_KEYS];
+$jq = JsonQueryWrapper\JsonQueryFactory::createWith('test.json', $options);
+$jq->run('.Foo.Bar'); # string(33)
+```
+
 
 ## Data Providers
 

--- a/src/JsonQueryWrapper/CommandLineOption/CommandLineOption.php
+++ b/src/JsonQueryWrapper/CommandLineOption/CommandLineOption.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace JsonQueryWrapper\CommandLineOption;
+
+class CommandLineOption implements CommandLineOptionInterface
+{
+    /**
+     * @param array
+     */
+    protected $options;
+
+    public function __construct(array $options = [])
+    {
+        $this->options = [];
+        foreach ($options as $option) {
+            $this->addOption($option);
+        }
+    }
+
+    public function addOption(string $option): void
+    {
+        if (!in_array($option, $this->options) && static::isValidOption($option)) {
+            $this->options[] = $option;
+        }
+    }
+
+    public static function isValidOption(string $option): bool
+    {
+        $reflector = new \ReflectionClass(CommandLineOptionInterface::class);
+        $availableOptions = array_values($reflector->getConstants());
+        return in_array($option, $availableOptions);
+    }
+
+    public function getOptionsAsString(): ?string
+    {
+        return empty($this->options) ? null : '-' . implode('', $this->options);
+    }
+
+    public function removeOption(string $option): void
+    {
+        $optionIndex = array_keys($this->options, $option)[0] ?? null;
+        if ($optionIndex !== null) {
+            unset($this->options[$optionIndex]);
+            $this->options = array_values($this->options);
+        }
+    }
+}

--- a/src/JsonQueryWrapper/CommandLineOption/CommandLineOptionInterface.php
+++ b/src/JsonQueryWrapper/CommandLineOption/CommandLineOptionInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace JsonQueryWrapper\CommandLineOption;
+
+interface CommandLineOptionInterface
+{
+    const OPTION_EXIT_BASED_ON_OUTPUT = 'e';
+    const OPTION_INPUT_RAW = 'R';
+    const OPTION_NULL_INPUT = 'n';
+    const OPTION_OUTPUT_COLORIZE = 'C';
+    const OPTION_OUTPUT_COMPACT = 'c';
+    const OPTION_OUTPUT_JOIN = 'j';
+    const OPTION_OUTPUT_MONOCHROME = 'M';
+    const OPTION_OUTPUT_RAW = 'r';
+    const OPTION_OUTPUT_SORT_KEYS = 'S';
+
+    public function addOption(string $option): void;
+    public static function isValidOption(string $option): bool;
+    public function getOptionsAsString(): ?string;
+    public function removeOption(string $option): void;
+}

--- a/src/JsonQueryWrapper/DataTypeMapper.php
+++ b/src/JsonQueryWrapper/DataTypeMapper.php
@@ -29,31 +29,17 @@ class DataTypeMapper
      */
     public function map($value)
     {
-        if ($value === 'true') {
-            return true;
-        }
-
-        if ($value === 'false') {
-            return false;
+        $boolean = filter_var($value, FILTER_VALIDATE_BOOL, FILTER_NULL_ON_FAILURE);
+        if ($boolean !== null) {
+            return $boolean;
         }
 
         if ($value === 'null') {
-            return;
+            return null;
         }
 
-        // Map integers
-        if (preg_match('/^(\d+)$/', $value, $matches)) {
-            return (int) $matches[1];
-        }
-
-        // Map floats
-        if (preg_match('/^(\d+\.\d+)$/', $value, $matches)) {
-            return (float) $matches[1];
-        }
-
-        // Map strings
-        if (preg_match('/^"(.*)"$/', $value, $matches)) {
-            return $matches[1];
+        if (is_numeric($value)) {
+            return $value + 0;
         }
 
         // Map parser error
@@ -61,6 +47,15 @@ class DataTypeMapper
             throw new DataTypeMapperException($matches[1]);
         }
 
+        // Map strings
+        if (preg_match('/^"(.*)"$/', $value, $matches)) {
+            return $matches[1];
+        }
+
+        $data = json_decode($value);
+        if ($data !== null) {
+            return $data;
+        }
         return $value;
     }
 }

--- a/src/JsonQueryWrapper/JsonQueryFactory.php
+++ b/src/JsonQueryWrapper/JsonQueryFactory.php
@@ -11,34 +11,40 @@
 
 namespace JsonQueryWrapper;
 
+use JsonQueryWrapper\CommandLineOption\CommandLineOption;
 use JsonQueryWrapper\DataProvider\File;
 use JsonQueryWrapper\DataProvider\Text;
 use JsonQueryWrapper\Process\ProcessFactory;
 
 class JsonQueryFactory
 {
+    const DEFAULT_OPTIONS = [CommandLineOption::OPTION_OUTPUT_MONOCHROME];
+
     /**
      * Creates a JsonQuery object without data provider.
      *
+     * @param array $options command line options
+     *
      * @return JsonQuery
      */
-    public static function create()
+    public static function create($options = self::DEFAULT_OPTIONS)
     {
-        return new JsonQuery(new ProcessFactory(), new DataTypeMapper());
+        return new JsonQuery(new ProcessFactory(), new DataTypeMapper(), new CommandLineOption($options));
     }
 
     /**
      * Creates a JsonQuery object with data provider.
      *
      * @param string $filenameOrText A path to a json file or json text
+     * @param array $options command line options
      *
      * @return JsonQuery
      */
-    public static function createWith($filenameOrText)
+    public static function createWith($filenameOrText, $options = self::DEFAULT_OPTIONS)
     {
         $provider = file_exists($filenameOrText) ? new File($filenameOrText) : new Text($filenameOrText);
 
-        $jq = new JsonQuery(new ProcessFactory(), new DataTypeMapper());
+        $jq = new JsonQuery(new ProcessFactory(), new DataTypeMapper(), new CommandLineOption($options));
         $jq->setDataProvider($provider);
 
         return $jq;

--- a/tests/JsonQueryWrapper/CommandLineOptionTest.php
+++ b/tests/JsonQueryWrapper/CommandLineOptionTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace JsonQueryWrapper\CommandLineOption;
+
+use PHPUnit\Framework\TestCase;
+
+class CommandLineOptionTest extends TestCase
+{
+    public function testEmptyCommandLineOptions()
+    {
+        $options = new CommandLineOption();
+        $this->assertNull($options->getOptionsAsString());
+    }
+
+    public function testAddingCommandLineOptions()
+    {
+        $options = new CommandLineOption();
+        $options->addOption(CommandLineOption::OPTION_OUTPUT_JOIN);
+        $options->addOption(CommandLineOption::OPTION_OUTPUT_SORT_KEYS);
+        $this->assertEquals($options->getOptionsAsString(), '-jS');
+    }
+
+    public function testAddingDuplicateCommandLineOptions()
+    {
+        $options = new CommandLineOption();
+        $options->addOption(CommandLineOption::OPTION_OUTPUT_JOIN);
+        $options->addOption(CommandLineOption::OPTION_OUTPUT_SORT_KEYS);
+        $this->assertEquals($options->getOptionsAsString(), '-jS');
+        $options->addOption(CommandLineOption::OPTION_OUTPUT_JOIN);
+        $options->addOption(CommandLineOption::OPTION_OUTPUT_SORT_KEYS);
+        $this->assertEquals($options->getOptionsAsString(), '-jS');
+    }
+
+    public function testRemovingCommandLineOptions()
+    {
+        $options = new CommandLineOption();
+        $options->addOption(CommandLineOption::OPTION_OUTPUT_JOIN);
+        $options->addOption(CommandLineOption::OPTION_OUTPUT_SORT_KEYS);
+        $this->assertEquals($options->getOptionsAsString(), '-jS');
+        $options->removeOption(CommandLineOption::OPTION_OUTPUT_SORT_KEYS);
+        $this->assertEquals($options->getOptionsAsString(), '-j');
+    }
+}

--- a/tests/JsonQueryWrapper/DataTypeMapperTest.php
+++ b/tests/JsonQueryWrapper/DataTypeMapperTest.php
@@ -78,10 +78,8 @@ class DataTypeMapperTest extends TestCase
 
     public function testJson()
     {
-        $this->markTestIncomplete('Need to decide whether to convert JSON data');
-
-        $json = ['Foo' => ['Bar' => 33]];
-        $this->assertEquals('Foo', $this->mapper->map(json_encode($json)));
+        $json = (object)['Foo' => (object)['Bar' => 33]];
+        $this->assertEquals($json, $this->mapper->map(json_encode($json)));
     }
 
     public function testGarbage()

--- a/tests/JsonQueryWrapper/JsonQueryTest.php
+++ b/tests/JsonQueryWrapper/JsonQueryTest.php
@@ -30,6 +30,8 @@ class JsonQueryTest extends TestCase
 
         $process = $this->createMock(Process::class);
         $process
+            ->method('mustRun');
+        $process
             ->method('run');
 
         $process
@@ -49,7 +51,7 @@ class JsonQueryTest extends TestCase
         );
 
         $sut->setDataProvider($dataProvider);
-        static::assertEquals(
+        $this->assertEquals(
             $expected,
             $sut->run('.name')
         );


### PR DESCRIPTION
Hi,

Thank you for this wonderful composer package. It is very useful to me. I had a use case where I needed to adjust the command line options passed to `jq`. I created some classes that can be optionally attached to the factory methods to allow for the use of different command line options. I preserved the default behavior of only using the `-M` option if nothing is specified to preserve existing deployments of the package. I hope you find this addition useful.

Dylan