### PR TITLE
Fix README.md installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ json-query-wrapper is a wrapper for the popular command-line JSON processor "[jq
 ## Installation
 
 ```bash
-$ composer require invoicesharing/json-query-wrapper
+$ composer require estahn/json-query-wrapper
 ```
 
 ## Usage


### PR DESCRIPTION
Seems like an unintended change from a fork slipped through into the README.